### PR TITLE
Update requirements.txt to exclude incompatible dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # GRPC / Protobuff related
-grpcio>=1.19.0
-grpcio-tools>=1.19.0
+grpcio>=1.19.0,<=1.48.2
+grpcio-tools>=1.19.0,<=1.48.2
 
 # Time related utils
 pytz


### PR DESCRIPTION
As you're aware, recent versions of the dependencies `grpcio` and `grpcio-tools` interact with `protobuf` in a way that prevents establishing a BTrDB connection object. This PR is just a quick edit to requirements.txt to exclude those incompatible versions and allow `pip install btrdb` to yield a working package. 

I did not test every version in between the originally spec'ed 1.19.0 and 1.48.2, but I did test enough near the upper end to feel confident that this provides a suitable temporary patch.